### PR TITLE
Adding variable types and fixing ip_set_descriptor for regional

### DIFF
--- a/global/vars.tf
+++ b/global/vars.tf
@@ -1,3 +1,7 @@
-variable "waf_prefix" {}
-variable "blacklisted_ips" {}
+variable "waf_prefix" {
+    type = "list"
+}
+variable "blacklisted_ips" {
+    type = "list"
+}
 variable "admin_remote_ipset" {}

--- a/regional/vars.tf
+++ b/regional/vars.tf
@@ -1,3 +1,7 @@
 variable "waf_prefix" {}
-variable "blacklisted_ips" {}
-variable "admin_remote_ipset" {}
+variable "blacklisted_ips" {
+    type = "list"
+}
+variable "admin_remote_ipset" {
+    type = "list"
+}

--- a/regional/waf_condition_ip.tf
+++ b/regional/waf_condition_ip.tf
@@ -1,9 +1,9 @@
 resource "aws_wafregional_ipset" "admin_remote_ipset" {
   name               = "${var.waf_prefix}-generic-match-admin-remote-ip"
-  ip_set_descriptors = "${var.admin_remote_ipset}"
+  ip_set_descriptor  = "${var.admin_remote_ipset}"
 }
 
 resource "aws_wafregional_ipset" "blacklisted_ips" {
   name               = "${var.waf_prefix}-generic-match-blacklisted-ips"
-  ip_set_descriptors = "${var.blacklisted_ips}"
+  ip_set_descriptor  = "${var.blacklisted_ips}"
 }


### PR DESCRIPTION
Until PR https://github.com/terraform-providers/terraform-provider-aws/pull/5319 is merged in, the regional ip_set_descriptor value is invalid.

Add the input variables to specify lists since defaults for string are invalid.