### PR TITLE
Allow customising rule_action to set it e.g. to COUNT

### DIFF
--- a/example/global_waf/global_waf.tf
+++ b/example/global_waf/global_waf.tf
@@ -3,6 +3,7 @@ module "global_waf" {
   waf_prefix         = var.waf_prefix
   blacklisted_ips    = var.blacklisted_ips
   admin_remote_ipset = var.admin_remote_ipset
+  rule_action        = var.rule_action
 }
 
 # Use module.global_waf.web_acl_id variable to attach it to aws_cloudfront_distribution

--- a/example/global_waf/vars.tf
+++ b/example/global_waf/vars.tf
@@ -7,3 +7,5 @@ variable "waf_prefix" {}
 variable "blacklisted_ips" {}
 
 variable "admin_remote_ipset" {}
+
+variable "rule_action" {}

--- a/example/regional_waf/regional_waf.tf
+++ b/example/regional_waf/regional_waf.tf
@@ -3,6 +3,7 @@ module "regional_waf" {
   waf_prefix         = var.waf_prefix
   blacklisted_ips    = var.blacklisted_ips
   admin_remote_ipset = var.admin_remote_ipset
+  rule_action        = var.rule_action
 }
 
 # Use module.regional_waf.web_acl_id variable to create aws_wafregional_web_acl_association

--- a/example/regional_waf/vars.tf
+++ b/example/regional_waf/vars.tf
@@ -7,3 +7,5 @@ variable "waf_prefix" {}
 variable "blacklisted_ips" {}
 
 variable "admin_remote_ipset" {}
+
+variable "rule_action" {}

--- a/global/vars.tf
+++ b/global/vars.tf
@@ -10,3 +10,6 @@ variable "admin_remote_ipset" {
   type = "list"
 }
 
+variable "rule_action" {
+  default = "BLOCK"
+}

--- a/global/waf_web_acl.tf
+++ b/global/waf_web_acl.tf
@@ -18,7 +18,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 2
@@ -28,7 +28,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 3
@@ -38,7 +38,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 4
@@ -48,7 +48,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 5
@@ -58,7 +58,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 6
@@ -68,7 +68,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 7
@@ -78,7 +78,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 8
@@ -88,7 +88,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 9
@@ -98,7 +98,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
   rules {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 10

--- a/regional/vars.tf
+++ b/regional/vars.tf
@@ -7,3 +7,7 @@ variable "blacklisted_ips" {
 variable "admin_remote_ipset" {
   type = "list"
 }
+
+variable "rule_action" {
+  default = "BLOCK"
+}

--- a/regional/waf_web_acl.tf
+++ b/regional/waf_web_acl.tf
@@ -8,7 +8,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 1
@@ -18,7 +18,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 2
@@ -28,7 +28,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 3
@@ -38,7 +38,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 4
@@ -48,7 +48,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 5
@@ -58,7 +58,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 6
@@ -68,7 +68,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 7
@@ -78,7 +78,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 8
@@ -88,7 +88,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 9
@@ -98,7 +98,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.rule_action
     }
 
     priority = 10


### PR DESCRIPTION
Hi, I'd like to have a "dry-run" of the WAF rules before rolling them out to environment.

WAF allows to "COUNT" blocked requests without actually blocking them. With that you can ensure you don't block the traffic you wouldn't want to. 

It's an optional thing, by default I keep using "BLOCK". 

LMK what you think. 